### PR TITLE
[Fix] Prevent mcmmo from modifing fish itemmeta

### DIFF
--- a/src/main/kotlin/me/elsiff/morefish/hooker/McmmoHooker.kt
+++ b/src/main/kotlin/me/elsiff/morefish/hooker/McmmoHooker.kt
@@ -1,8 +1,13 @@
 package me.elsiff.morefish.hooker
 
 import com.gmail.nossr50.api.ExperienceAPI
+import com.gmail.nossr50.events.skills.fishing.McMMOPlayerFishingTreasureEvent
+import com.gmail.nossr50.events.skills.fishing.McMMOPlayerMagicHunterEvent
 import me.elsiff.morefish.MoreFish
+import org.bukkit.Bukkit
 import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
 
 /**
  * Created by elsiff on 2019-01-20.
@@ -12,9 +17,27 @@ class McmmoHooker : PluginHooker {
     override var hasHooked: Boolean = false
 
     override fun hook(plugin: MoreFish) {
+        Bukkit.getPluginManager().registerEvents(McmmoFishingFixer(plugin), plugin)
         hasHooked = true
     }
 
     fun skillLevelOf(player: Player, skillType: String): Int =
-        ExperienceAPI.getLevel(player, skillType)
+            ExperienceAPI.getLevel(player, skillType)
+
+    class McmmoFishingFixer(val plugin: MoreFish): Listener {
+
+        @EventHandler(ignoreCancelled = true)
+        fun onMcmmoFishOnFishContest(event: McMMOPlayerFishingTreasureEvent) {
+            if (plugin.competition.isEnabled()) {
+                event.isCancelled = true
+            }
+        }
+
+        @EventHandler(ignoreCancelled = true)
+        fun onMcmmoFishOnFishContest(event: McMMOPlayerMagicHunterEvent) {
+            if (plugin.competition.isEnabled()) {
+                event.isCancelled = true
+            }
+        }
+    }
 }

--- a/src/main/kotlin/me/elsiff/morefish/hooker/McmmoHooker.kt
+++ b/src/main/kotlin/me/elsiff/morefish/hooker/McmmoHooker.kt
@@ -4,6 +4,7 @@ import com.gmail.nossr50.api.ExperienceAPI
 import com.gmail.nossr50.events.skills.fishing.McMMOPlayerFishingTreasureEvent
 import com.gmail.nossr50.events.skills.fishing.McMMOPlayerMagicHunterEvent
 import me.elsiff.morefish.MoreFish
+import me.elsiff.morefish.configuration.Config
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
@@ -27,15 +28,13 @@ class McmmoHooker : PluginHooker {
     class McmmoFishingFixer(val plugin: MoreFish): Listener {
 
         @EventHandler(ignoreCancelled = true)
-        fun onMcmmoFishOnFishContest(event: McMMOPlayerFishingTreasureEvent) {
-            if (plugin.competition.isEnabled()) {
-                event.isCancelled = true
-            }
-        }
+        fun onMcmmoFishOnFishContest(event: McMMOPlayerFishingTreasureEvent) = cancelMcmmoFishOnFishContest(event)
 
         @EventHandler(ignoreCancelled = true)
-        fun onMcmmoFishOnFishContest(event: McMMOPlayerMagicHunterEvent) {
-            if (plugin.competition.isEnabled()) {
+        fun onMcmmoFishOnFishContest(event: McMMOPlayerMagicHunterEvent) = cancelMcmmoFishOnFishContest(event)
+
+        private fun cancelMcmmoFishOnFishContest(event: McMMOPlayerFishingTreasureEvent) {
+            if (Config.standard.boolean("general.no-fishing-unless-contest") || plugin.competition.isEnabled()) {
                 event.isCancelled = true
             }
         }

--- a/src/main/kotlin/me/elsiff/morefish/hooker/McmmoHooker.kt
+++ b/src/main/kotlin/me/elsiff/morefish/hooker/McmmoHooker.kt
@@ -34,7 +34,7 @@ class McmmoHooker : PluginHooker {
         fun onMcmmoFishOnFishContest(event: McMMOPlayerMagicHunterEvent) = cancelMcmmoFishOnFishContest(event)
 
         private fun cancelMcmmoFishOnFishContest(event: McMMOPlayerFishingTreasureEvent) {
-            if (Config.standard.boolean("general.no-fishing-unless-contest") || plugin.competition.isEnabled()) {
+            if (!Config.standard.boolean("general.only-for-contest") || plugin.competition.isEnabled()) {
                 event.isCancelled = true
             }
         }


### PR DESCRIPTION
mcMMO fishing skill will modify fish caught. For example, add enchantment or change material type.
Stopped it by listenening mcmmo fishing skill event.