### PR TITLE
[Change] caught fish rarity pickup algorithm

### DIFF
--- a/src/main/kotlin/me/elsiff/morefish/fishing/FishTypeTable.kt
+++ b/src/main/kotlin/me/elsiff/morefish/fishing/FishTypeTable.kt
@@ -8,7 +8,6 @@ import org.bukkit.entity.Player
  * Created by elsiff on 2019-01-09.
  */
 interface FishTypeTable : Map<FishRarity, Set<FishType>> {
-    val defaultRarity: FishRarity?
     val rarities: Set<FishRarity>
     val types: Set<FishType>
 

--- a/src/main/kotlin/me/elsiff/morefish/fishing/MutableFishTypeTable.kt
+++ b/src/main/kotlin/me/elsiff/morefish/fishing/MutableFishTypeTable.kt
@@ -27,8 +27,13 @@ class MutableFishTypeTable : HashMap<FishRarity, Set<FishType>>(), FishTypeTable
                 return rarity
             }
         }
-        // Only when there is no rarity.
-        throw IllegalStateException("Add rarity at least 1")
+
+        if (rarities.isEmpty()) {
+            throw IllegalStateException("Add rarity at least 1")
+        }
+
+        // return biggest chance rarity.
+        return rarities[rarities.size - 1]
     }
 
     override fun pickRandomType(rarity: FishRarity): FishType {

--- a/src/main/kotlin/me/elsiff/morefish/fishing/MutableFishTypeTable.kt
+++ b/src/main/kotlin/me/elsiff/morefish/fishing/MutableFishTypeTable.kt
@@ -9,16 +9,6 @@ import kotlin.random.Random
  * Created by elsiff on 2018-12-23.
  */
 class MutableFishTypeTable : HashMap<FishRarity, Set<FishType>>(), FishTypeTable {
-    override val defaultRarity: FishRarity?
-        get() {
-            val defaultRarities = rarities.filter { it.default }
-            check(defaultRarities.size <= 1) { "Default rarity must be only one" }
-
-            return if (!defaultRarities.isEmpty())
-                return defaultRarities[0]
-            else
-                null
-        }
 
     override val rarities: Set<FishRarity>
         get() = keys.toSet()
@@ -27,9 +17,7 @@ class MutableFishTypeTable : HashMap<FishRarity, Set<FishType>>(), FishTypeTable
         get() = values.flatten().toSet()
 
     override fun pickRandomRarity(): FishRarity {
-        val probabilitySum = rarities
-            .filter { !it.default }
-            .sumByDouble { it.probability }
+        val probabilitySum = rarities.sumByDouble { it.probability }
 
         val rarities = keys.toList().filter { !it.default }.sortedBy { it.probability }
         val randomVal = Random.nextDouble()
@@ -39,8 +27,8 @@ class MutableFishTypeTable : HashMap<FishRarity, Set<FishType>>(), FishTypeTable
                 return rarity
             }
         }
-        // Only when all rarity chance is 0
-        return defaultRarity ?: throw IllegalStateException("Default rarity doesn't exist")
+        // Only when there is no rarity.
+        throw IllegalStateException("Add rarity at least 1")
     }
 
     override fun pickRandomType(rarity: FishRarity): FishType {

--- a/src/main/kotlin/me/elsiff/morefish/fishing/MutableFishTypeTable.kt
+++ b/src/main/kotlin/me/elsiff/morefish/fishing/MutableFishTypeTable.kt
@@ -30,19 +30,16 @@ class MutableFishTypeTable : HashMap<FishRarity, Set<FishType>>(), FishTypeTable
         val probabilitySum = rarities
             .filter { !it.default }
             .sumByDouble { it.probability }
-        check(probabilitySum <= 1.0) { "Sum of rarity probabilities must not be bigger than 1.0" }
 
-        val rarities = keys
+        val rarities = keys.toList().filter { !it.default }.sortedBy { it.probability }
         val randomVal = Random.nextDouble()
-        var chanceSum = 0.0
         for (rarity in rarities) {
-            if (!rarity.default) {
-                chanceSum += rarity.probability
-                if (randomVal <= chanceSum) {
-                    return rarity
-                }
+            // Weighted selection (probability / probabilitySum <= 1.0)
+            if (randomVal <= rarity.probability / probabilitySum) {
+                return rarity
             }
         }
+        // Only when all rarity chance is 0
         return defaultRarity ?: throw IllegalStateException("Default rarity doesn't exist")
     }
 

--- a/src/main/resources/locale/fish_de.yml
+++ b/src/main/resources/locale/fish_de.yml
@@ -23,7 +23,6 @@ item-format:
 rarity-list:
   common:
     display-name: "Oft"
-    default: true
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_de.yml
+++ b/src/main/resources/locale/fish_de.yml
@@ -23,6 +23,7 @@ item-format:
 rarity-list:
   common:
     display-name: "Oft"
+    chance: 70
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_en.yml
+++ b/src/main/resources/locale/fish_en.yml
@@ -23,7 +23,6 @@ item-format:
 rarity-list:
   common:
     display-name: "COMMON"
-    default: true
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_en.yml
+++ b/src/main/resources/locale/fish_en.yml
@@ -23,6 +23,7 @@ item-format:
 rarity-list:
   common:
     display-name: "COMMON"
+    chance: 70
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_jp.yml
+++ b/src/main/resources/locale/fish_jp.yml
@@ -23,7 +23,6 @@ item-format:
 rarity-list:
   common:
     display-name: "普通"
-    default: true
     color: "reset"
     announcement: 0
     no-display: true

--- a/src/main/resources/locale/fish_jp.yml
+++ b/src/main/resources/locale/fish_jp.yml
@@ -23,6 +23,7 @@ item-format:
 rarity-list:
   common:
     display-name: "普通"
+    chance: 70
     color: "reset"
     announcement: 0
     no-display: true

--- a/src/main/resources/locale/fish_kr.yml
+++ b/src/main/resources/locale/fish_kr.yml
@@ -23,7 +23,6 @@ item-format:
 rarity-list:
   common:
     display-name: "일반"
-    default: true
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_kr.yml
+++ b/src/main/resources/locale/fish_kr.yml
@@ -23,6 +23,7 @@ item-format:
 rarity-list:
   common:
     display-name: "일반"
+    chance: 70
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_pl.yml
+++ b/src/main/resources/locale/fish_pl.yml
@@ -23,7 +23,6 @@ item-format:
 rarity-list:
   common:
     display-name: "ZWYCZAJNA"
-    default: true
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_pl.yml
+++ b/src/main/resources/locale/fish_pl.yml
@@ -23,6 +23,7 @@ item-format:
 rarity-list:
   common:
     display-name: "ZWYCZAJNA"
+    chance: 70
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_tw.yml
+++ b/src/main/resources/locale/fish_tw.yml
@@ -23,6 +23,7 @@ item-format:
 rarity-list:
   common:
     display-name: "一般"
+    chance: 70
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_tw.yml
+++ b/src/main/resources/locale/fish_tw.yml
@@ -23,7 +23,6 @@ item-format:
 rarity-list:
   common:
     display-name: "一般"
-    default: true
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_vn.yml
+++ b/src/main/resources/locale/fish_vn.yml
@@ -23,6 +23,7 @@ item-format:
 rarity-list:
   common:
     display-name: "Thường"
+    chance: 70
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_vn.yml
+++ b/src/main/resources/locale/fish_vn.yml
@@ -23,7 +23,6 @@ item-format:
 rarity-list:
   common:
     display-name: "Thường"
-    default: true
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_zh_cn.yml
+++ b/src/main/resources/locale/fish_zh_cn.yml
@@ -23,6 +23,7 @@ item-format:
 rarity-list:
   common:
     display-name: "一般"
+    chance: 70
     color: "reset"
     additional-price: 0.0
     announcement: 0

--- a/src/main/resources/locale/fish_zh_cn.yml
+++ b/src/main/resources/locale/fish_zh_cn.yml
@@ -23,7 +23,6 @@ item-format:
 rarity-list:
   common:
     display-name: "一般"
-    default: true
     color: "reset"
     additional-price: 0.0
     announcement: 0


### PR DESCRIPTION
Current algorithm can produce Exception.

So I changed it not to produce it.
With new algorithm, sum of all chance can exceed 1.0. And default rarity will be selected only when probability sum is 0.
I think we can remove default property.